### PR TITLE
Separate Shomei RPC for Linea

### DIFF
--- a/src/linea/LineaRollup.ts
+++ b/src/linea/LineaRollup.ts
@@ -10,10 +10,10 @@ import type {
   ProviderPair,
   ProofSequence,
 } from '../types.js';
-import { Interface } from 'ethers/abi';
 import { Contract, EventLog } from 'ethers/contract';
 import { JsonRpcProvider } from 'ethers/providers';
 import { LineaProver } from './LineaProver.js';
+import { ROLLUP_ABI } from './types.js';
 import { CHAINS } from '../chains.js';
 import { ABI_CODER } from '../utils.js';
 
@@ -22,31 +22,6 @@ import { ABI_CODER } from '../utils.js';
 // https://consensys.io/diligence/audits/2024/06/linea-ens/
 // https://github.com/Consensys/linea-monorepo/blob/main/contracts/test/SparseMerkleProof.ts
 // https://github.com/Consensys/linea-ens/blob/main/packages/linea-state-verifier/contracts/LineaSparseProofVerifier.sol
-
-const ROLLUP_ABI = new Interface([
-  // ZkEvmV2.sol
-  `function currentL2BlockNumber() view returns (uint256)`,
-  `function stateRootHashes(uint256 l2BlockNumber) view returns (bytes32)`,
-  // ILineaRollup.sol
-  `event DataFinalized(
-	uint256 indexed lastBlockFinalized,
-	bytes32 indexed startingRootHash,
-	bytes32 indexed finalRootHash,
-	bool withProof
-  )`,
-  `event DataFinalizedV3(
-	uint256 indexed startBlockNumber,
-	uint256 indexed endBlockNumber,
-	bytes32 indexed shnarf,
-	bytes32 parentStateRootHash,
-	bytes32 finalStateRootHash
-  )`,
-  `event BlocksVerificationDone(
-	uint256 indexed lastBlockFinalized,
-	bytes32 startingRootHash,
-	bytes32 finalRootHash
-  )`,
-]);
 
 export type LineaConfig = {
   L1MessageService: HexAddress;
@@ -99,8 +74,8 @@ export class LineaRollup extends AbstractRollup<LineaCommit> {
       : undefined;
   }
 
-  readonly L1MessageService: Contract;
   readonly firstCommitV3: bigint | undefined;
+  readonly L1MessageService: Contract;
   constructor(providers: ProviderPair, config: LineaConfig) {
     super(providers);
     this.L1MessageService = new Contract(

--- a/src/linea/UnfinalizedLineaRollup.ts
+++ b/src/linea/UnfinalizedLineaRollup.ts
@@ -7,73 +7,10 @@ import type {
 } from '../types.js';
 import { keccak256 } from 'ethers/crypto';
 import { Contract } from 'ethers/contract';
-import { Interface } from 'ethers/abi';
 import { LineaProver } from './LineaProver.js';
+import { ROLLUP_ABI } from './types.js';
 import { ABI_CODER, fetchBlock, MAINNET_BLOCK_SEC } from '../utils.js';
 import type { LineaConfig } from './LineaRollup.js';
-
-// https://github.com/Consensys/linea-monorepo/blob/main/contracts/src/rollup/LineaRollup.sol
-const ROLLUP_ABI = new Interface([
-  `event DataSubmittedV3(
-    bytes32 parentShnarf,
-    bytes32 indexed shnarf,
-    bytes32 finalStateRootHash
-  )`,
-  `function submitBlobs(
-    (
-      uint256 dataEvaluationClaim,
-      bytes kzgCommitment,
-      bytes kzgProof,
-      bytes32 finalStateRootHash,
-      bytes32 snarkHash
-    )[] blobSubmissionData,
-    bytes32 parentShnarf,
-    bytes32 finalBlobShnarf
-  ) external`,
-]);
-
-type ABIBlobData = {
-  dataEvaluationClaim: bigint;
-  kzgCommitment: HexString;
-  kzgProof: HexString;
-  finalStateRootHash: HexString32;
-  snarkHash: HexString32;
-};
-
-// const ROLLUP_ABI_OLD = new Interface([
-//   `event DataSubmittedV2(
-//     bytes32 indexed shnarf,
-//     uint256 indexed startBlock,
-//     uint256 indexed endBlock
-//   )`,
-//   `function submitBlobs(
-//     (
-//       (
-//         bytes32 finalStateRootHash,
-//         uint256 firstBlockInData,
-//         uint256 finalBlockInData,
-//         bytes32 snarkHash
-//       ) submissionData,
-//       uint256 dataEvaluationClaim,
-//       bytes kzgCommitment,
-//       bytes kzgProof
-//     )[] blobSubmissionData,
-//     bytes32 parentShnarf,
-//     bytes32 finalBlobShnarf
-//   ) external`,
-// ]);
-
-// type ABIBlobData = {
-// 	submissionData: {
-// 	  finalStateRootHash: HexString32;
-// 	  firstBlockInData: bigint;
-// 	  finalBlockInData: bigint;
-// 	  snarkHash: HexString32;
-// 	};
-// 	dataEvaluationClaim: bigint;
-// 	kzgCommitment: HexString;
-// 	kzgProof: HexString;
-//   };
 
 export type UnfinalizedLineaCommit = RollupCommit<LineaProver> & {
   readonly abiEncodedTuple: HexString;
@@ -81,13 +18,12 @@ export type UnfinalizedLineaCommit = RollupCommit<LineaProver> & {
 };
 
 export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommit> {
-  readonly L1MessageService: Contract;
+  readonly L1MessageService;
   constructor(
     providers: ProviderPair,
     config: LineaConfig,
     readonly minAgeBlocks: number
   ) {
-    if (!config.firstCommitV3) throw new Error('expected V3');
     super(providers);
     this.L1MessageService = new Contract(
       config.L1MessageService,
@@ -108,7 +44,7 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
       const logs = await this.provider1.getLogs({
         address: this.L1MessageService.target,
         topics: [
-          this.L1MessageService.filters.DataSubmittedV3.fragment.topicHash,
+          this.L1MessageService.filters.DataSubmittedV2.fragment.topicHash,
         ],
         fromBlock: i < step ? 0 : i + 1 - step,
         toBlock: i,
@@ -122,26 +58,38 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
     commit: UnfinalizedLineaCommit
   ): Promise<bigint> {
     const [event] = await this.L1MessageService.queryFilter(
-      this.L1MessageService.filters.DataSubmittedV3(null, commit.parentShnarf)
+      this.L1MessageService.filters.DataSubmittedV2(commit.parentShnarf)
     );
     if (!event) throw new Error(`no earlier shnarf: ${commit.index}`);
     return BigInt(event.blockNumber);
+    //return this.L1MessageService.shnarfFinalBlockNumbers(commit.parentShnarf);
   }
   protected override async _fetchCommit(
     index: bigint
   ): Promise<UnfinalizedLineaCommit> {
     const [event] = await this.L1MessageService.queryFilter(
-      this.L1MessageService.filters.DataSubmittedV3(),
+      this.L1MessageService.filters.DataSubmittedV2(),
       index,
       index
     );
-    if (!event) throw new Error(`no DataSubmittedV3`);
+    if (!event) throw new Error(`no DataSubmittedV2`);
     const tx = await event.getTransaction();
     if (!tx || !tx.blockNumber || !tx.blobVersionedHashes) {
       throw new Error(`no submit tx: ${event.transactionHash}`);
     }
     const desc = this.L1MessageService.interface.parseTransaction(tx);
-    if (!desc) throw new Error(`unable to parse tx: ${tx.hash}`);
+    if (!desc) throw new Error(`unable to parse tx`);
+    type ABIBlobData = {
+      submissionData: {
+        finalStateRootHash: HexString32;
+        firstBlockInData: bigint;
+        finalBlockInData: bigint;
+        snarkHash: HexString32;
+      };
+      dataEvaluationClaim: bigint;
+      kzgCommitment: HexString;
+      kzgProof: HexString;
+    };
     const blobs = desc.args.blobSubmissionData as ABIBlobData[];
     if (!blobs.length) throw new Error('expected blobs');
     const parentShnarf = desc.args.parentShnarf as HexString32;
@@ -152,15 +100,15 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
       const currentDataEvaluationPoint = keccak256(
         ABI_CODER.encode(
           ['bytes32', 'bytes32'],
-          [blob.snarkHash, tx.blobVersionedHashes[i]]
+          [blob.submissionData.snarkHash, tx.blobVersionedHashes[i]]
         )
       );
       abiEncodedTuple = ABI_CODER.encode(
         ['bytes32', 'bytes32', 'bytes32', 'bytes32', 'uint256'],
         [
           computedShnarf,
-          blob.snarkHash,
-          blob.finalStateRootHash,
+          blob.submissionData.snarkHash,
+          blob.submissionData.finalStateRootHash,
           currentDataEvaluationPoint,
           blob.dataEvaluationClaim,
         ]
@@ -170,17 +118,12 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
     if (computedShnarf !== desc.args.finalBlobShnarf) {
       throw new Error('shnarf mismatch');
     }
-    // TODO: the V3 design removed finalBlockInData
-    // i think this requires parsing l2BlockNumber from the blob data
-    // blobVersionedHash => blob function doesn't exist yet
-    // https://github.com/ethereum/beacon-APIs/issues/332
-    throw new Error('NOT IMPLEMENTED');
-    const l2BlockNumber = 0;
-    const prover = new LineaProver(this.provider2, l2BlockNumber);
-    //prover.shomeiProvider = this._shomeiProvider;
     return {
       index,
-      prover,
+      prover: new LineaProver(
+        this.provider2,
+        blobs[blobs.length - 1].submissionData.finalBlockInData // l2BlockNumber
+      ),
       abiEncodedTuple,
       parentShnarf,
     };

--- a/src/linea/UnfinalizedLineaRollup.ts
+++ b/src/linea/UnfinalizedLineaRollup.ts
@@ -7,10 +7,73 @@ import type {
 } from '../types.js';
 import { keccak256 } from 'ethers/crypto';
 import { Contract } from 'ethers/contract';
+import { Interface } from 'ethers/abi';
 import { LineaProver } from './LineaProver.js';
-import { ROLLUP_ABI } from './types.js';
 import { ABI_CODER, fetchBlock, MAINNET_BLOCK_SEC } from '../utils.js';
 import type { LineaConfig } from './LineaRollup.js';
+
+// https://github.com/Consensys/linea-monorepo/blob/main/contracts/src/rollup/LineaRollup.sol
+const ROLLUP_ABI = new Interface([
+  `event DataSubmittedV3(
+    bytes32 parentShnarf,
+    bytes32 indexed shnarf,
+    bytes32 finalStateRootHash
+  )`,
+  `function submitBlobs(
+    (
+      uint256 dataEvaluationClaim,
+      bytes kzgCommitment,
+      bytes kzgProof,
+      bytes32 finalStateRootHash,
+      bytes32 snarkHash
+    )[] blobSubmissionData,
+    bytes32 parentShnarf,
+    bytes32 finalBlobShnarf
+  ) external`,
+]);
+
+type ABIBlobData = {
+  dataEvaluationClaim: bigint;
+  kzgCommitment: HexString;
+  kzgProof: HexString;
+  finalStateRootHash: HexString32;
+  snarkHash: HexString32;
+};
+
+// const ROLLUP_ABI_OLD = new Interface([
+//   `event DataSubmittedV2(
+//     bytes32 indexed shnarf,
+//     uint256 indexed startBlock,
+//     uint256 indexed endBlock
+//   )`,
+//   `function submitBlobs(
+//     (
+//       (
+//         bytes32 finalStateRootHash,
+//         uint256 firstBlockInData,
+//         uint256 finalBlockInData,
+//         bytes32 snarkHash
+//       ) submissionData,
+//       uint256 dataEvaluationClaim,
+//       bytes kzgCommitment,
+//       bytes kzgProof
+//     )[] blobSubmissionData,
+//     bytes32 parentShnarf,
+//     bytes32 finalBlobShnarf
+//   ) external`,
+// ]);
+
+// type ABIBlobData = {
+// 	submissionData: {
+// 	  finalStateRootHash: HexString32;
+// 	  firstBlockInData: bigint;
+// 	  finalBlockInData: bigint;
+// 	  snarkHash: HexString32;
+// 	};
+// 	dataEvaluationClaim: bigint;
+// 	kzgCommitment: HexString;
+// 	kzgProof: HexString;
+//   };
 
 export type UnfinalizedLineaCommit = RollupCommit<LineaProver> & {
   readonly abiEncodedTuple: HexString;
@@ -18,12 +81,13 @@ export type UnfinalizedLineaCommit = RollupCommit<LineaProver> & {
 };
 
 export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommit> {
-  readonly L1MessageService;
+  readonly L1MessageService: Contract;
   constructor(
     providers: ProviderPair,
     config: LineaConfig,
     readonly minAgeBlocks: number
   ) {
+    if (!config.firstCommitV3) throw new Error('expected V3');
     super(providers);
     this.L1MessageService = new Contract(
       config.L1MessageService,
@@ -44,7 +108,7 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
       const logs = await this.provider1.getLogs({
         address: this.L1MessageService.target,
         topics: [
-          this.L1MessageService.filters.DataSubmittedV2.fragment.topicHash,
+          this.L1MessageService.filters.DataSubmittedV3.fragment.topicHash,
         ],
         fromBlock: i < step ? 0 : i + 1 - step,
         toBlock: i,
@@ -58,38 +122,26 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
     commit: UnfinalizedLineaCommit
   ): Promise<bigint> {
     const [event] = await this.L1MessageService.queryFilter(
-      this.L1MessageService.filters.DataSubmittedV2(commit.parentShnarf)
+      this.L1MessageService.filters.DataSubmittedV3(null, commit.parentShnarf)
     );
     if (!event) throw new Error(`no earlier shnarf: ${commit.index}`);
     return BigInt(event.blockNumber);
-    //return this.L1MessageService.shnarfFinalBlockNumbers(commit.parentShnarf);
   }
   protected override async _fetchCommit(
     index: bigint
   ): Promise<UnfinalizedLineaCommit> {
     const [event] = await this.L1MessageService.queryFilter(
-      this.L1MessageService.filters.DataSubmittedV2(),
+      this.L1MessageService.filters.DataSubmittedV3(),
       index,
       index
     );
-    if (!event) throw new Error(`no DataSubmittedV2`);
+    if (!event) throw new Error(`no DataSubmittedV3`);
     const tx = await event.getTransaction();
     if (!tx || !tx.blockNumber || !tx.blobVersionedHashes) {
       throw new Error(`no submit tx: ${event.transactionHash}`);
     }
     const desc = this.L1MessageService.interface.parseTransaction(tx);
-    if (!desc) throw new Error(`unable to parse tx`);
-    type ABIBlobData = {
-      submissionData: {
-        finalStateRootHash: HexString32;
-        firstBlockInData: bigint;
-        finalBlockInData: bigint;
-        snarkHash: HexString32;
-      };
-      dataEvaluationClaim: bigint;
-      kzgCommitment: HexString;
-      kzgProof: HexString;
-    };
+    if (!desc) throw new Error(`unable to parse tx: ${tx.hash}`);
     const blobs = desc.args.blobSubmissionData as ABIBlobData[];
     if (!blobs.length) throw new Error('expected blobs');
     const parentShnarf = desc.args.parentShnarf as HexString32;
@@ -100,15 +152,15 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
       const currentDataEvaluationPoint = keccak256(
         ABI_CODER.encode(
           ['bytes32', 'bytes32'],
-          [blob.submissionData.snarkHash, tx.blobVersionedHashes[i]]
+          [blob.snarkHash, tx.blobVersionedHashes[i]]
         )
       );
       abiEncodedTuple = ABI_CODER.encode(
         ['bytes32', 'bytes32', 'bytes32', 'bytes32', 'uint256'],
         [
           computedShnarf,
-          blob.submissionData.snarkHash,
-          blob.submissionData.finalStateRootHash,
+          blob.snarkHash,
+          blob.finalStateRootHash,
           currentDataEvaluationPoint,
           blob.dataEvaluationClaim,
         ]
@@ -118,12 +170,17 @@ export class UnfinalizedLineaRollup extends AbstractRollup<UnfinalizedLineaCommi
     if (computedShnarf !== desc.args.finalBlobShnarf) {
       throw new Error('shnarf mismatch');
     }
+    // TODO: the V3 design removed finalBlockInData
+    // i think this requires parsing l2BlockNumber from the blob data
+    // blobVersionedHash => blob function doesn't exist yet
+    // https://github.com/ethereum/beacon-APIs/issues/332
+    throw new Error('NOT IMPLEMENTED');
+    const l2BlockNumber = 0;
+    const prover = new LineaProver(this.provider2, l2BlockNumber);
+    //prover.shomeiProvider = this._shomeiProvider;
     return {
       index,
-      prover: new LineaProver(
-        this.provider2,
-        blobs[blobs.length - 1].submissionData.finalBlockInData // l2BlockNumber
-      ),
+      prover,
       abiEncodedTuple,
       parentShnarf,
     };

--- a/src/linea/types.ts
+++ b/src/linea/types.ts
@@ -1,6 +1,54 @@
 import type { HexString, HexString32 } from '../types.js';
+import { Interface } from 'ethers/abi';
 import { ABI_CODER, NULL_CODE_HASH } from '../utils.js';
 import { dataSlice } from 'ethers/utils';
+
+export const ROLLUP_ABI = new Interface([
+  // ZkEvmV2.sol
+  `function currentL2BlockNumber() view returns (uint256)`,
+  `function stateRootHashes(uint256 l2BlockNumber) view returns (bytes32)`,
+  `function shnarfFinalBlockNumbers(bytes32 shnarf) external view returns (uint256)`,
+  // ILineaRollup.sol
+  `event DataFinalized(
+    uint256 indexed lastBlockFinalized,
+    bytes32 indexed startingRootHash,
+    bytes32 indexed finalRootHash,
+    bool withProof
+  )`,
+  `event DataFinalizedV3(
+    uint256 indexed startBlockNumber,
+    uint256 indexed endBlockNumber,
+    bytes32 indexed shnarf,
+    bytes32 parentStateRootHash,
+    bytes32 finalStateRootHash
+  )`,
+  `event DataSubmittedV2(
+    bytes32 indexed shnarf,
+    uint256 indexed startBlock,
+    uint256 indexed endBlock
+  )`,
+  `function submitBlobs(
+    (
+      (
+	    bytes32 finalStateRootHash,
+        uint256 firstBlockInData,
+        uint256 finalBlockInData,
+        bytes32 snarkHash
+      ) submissionData,
+      uint256 dataEvaluationClaim,
+      bytes kzgCommitment,
+      bytes kzgProof
+    )[] blobSubmissionData,
+    bytes32 parentShnarf,
+    bytes32 finalBlobShnarf
+  ) external`,
+  // IZkEvmV2.sol
+  `event BlocksVerificationDone(
+    uint256 indexed lastBlockFinalized,
+    bytes32 startingRootHash,
+    bytes32 finalRootHash
+  )`,
+]);
 
 export type LineaProofObject = {
   proofRelatedNodes: HexString[];

--- a/src/linea/types.ts
+++ b/src/linea/types.ts
@@ -1,54 +1,6 @@
 import type { HexString, HexString32 } from '../types.js';
-import { Interface } from 'ethers/abi';
 import { ABI_CODER, NULL_CODE_HASH } from '../utils.js';
 import { dataSlice } from 'ethers/utils';
-
-export const ROLLUP_ABI = new Interface([
-  // ZkEvmV2.sol
-  `function currentL2BlockNumber() view returns (uint256)`,
-  `function stateRootHashes(uint256 l2BlockNumber) view returns (bytes32)`,
-  `function shnarfFinalBlockNumbers(bytes32 shnarf) external view returns (uint256)`,
-  // ILineaRollup.sol
-  `event DataFinalized(
-    uint256 indexed lastBlockFinalized,
-    bytes32 indexed startingRootHash,
-    bytes32 indexed finalRootHash,
-    bool withProof
-  )`,
-  `event DataFinalizedV3(
-    uint256 indexed startBlockNumber,
-    uint256 indexed endBlockNumber,
-    bytes32 indexed shnarf,
-    bytes32 parentStateRootHash,
-    bytes32 finalStateRootHash
-  )`,
-  `event DataSubmittedV2(
-    bytes32 indexed shnarf,
-    uint256 indexed startBlock,
-    uint256 indexed endBlock
-  )`,
-  `function submitBlobs(
-    (
-      (
-	    bytes32 finalStateRootHash,
-        uint256 firstBlockInData,
-        uint256 finalBlockInData,
-        bytes32 snarkHash
-      ) submissionData,
-      uint256 dataEvaluationClaim,
-      bytes kzgCommitment,
-      bytes kzgProof
-    )[] blobSubmissionData,
-    bytes32 parentShnarf,
-    bytes32 finalBlobShnarf
-  ) external`,
-  // IZkEvmV2.sol
-  `event BlocksVerificationDone(
-    uint256 indexed lastBlockFinalized,
-    bytes32 startingRootHash,
-    bytes32 finalRootHash
-  )`,
-]);
 
 export type LineaProofObject = {
   proofRelatedNodes: HexString[];


### PR DESCRIPTION
- added `setShomeiURL()` to `LineaRollup`
- added optional `shomeiProvider` to `LinearProver`

Note: this is untested because I don't have a Shomei provider to test.

Note: the tests only fail because of Sepolia (Pectra) which is fixed in BoLD PR.

---

Ideally, I would remove the `linea_getProof` workaround [here](https://github.com/unruggable-labs/unruggable-gateways/blob/main/src/GatewayProvider.ts#L10-L13) and [here](https://github.com/unruggable-labs/unruggable-gateways/blob/main/test/workarounds/linea-proof-batch.test.ts) and force the developer to supply two RPCs.  The problem is: the Shomei RPC needs to have batching disabled and URG design makes no assumptions about the choice of providers.  So I made it optional, and keep `GatewayProvider` workaround to fix the batch issue.